### PR TITLE
Revert "Use block.frequency instead of arg.frequency."

### DIFF
--- a/koovdev_action.js
+++ b/koovdev_action.js
@@ -763,7 +763,7 @@ function koov_actions(board, action_timeout, selected_device) {
     'buzzer-on': noreply((block, arg) => {
       const pin = KOOV_PORTS[block.port];
       if (typeof pin === 'number') {
-        buzzer_on(board, pin, block.frequency);
+        buzzer_on(board, pin, arg.frequency);
       }
     }),
     'buzzer-off': noreply(block => {


### PR DESCRIPTION
This reverts commit f28d82687ac363999ddd17b3ddaac2b893be6028.