### PR TITLE
Keep R/G/B pins low in init_multiled().  MultiLED stay off since FET …

### DIFF
--- a/koovdev_action.js
+++ b/koovdev_action.js
@@ -529,9 +529,12 @@ function koov_actions(board, action_timeout, selected_device) {
     buzzer_off(board, pin);
   };
   const init_multiled = port => {
-    ['LED_R', 'LED_G', 'LED_B', 'LED_FET'].forEach(x => {
-      board.pinMode(KOOV_PORTS[x], board.MODES.OUTPUT);
-      board.digitalWrite(KOOV_PORTS[x], board.HIGH);
+    board.pinMode(KOOV_PORTS['LED_FET'], board.MODES.OUTPUT);
+    board.digitalWrite(KOOV_PORTS['LED_FET'], board.HIGH);
+    RGB_STATE.forEach(x => {
+      x.state = false;
+      board.pinMode(x.pin, board.MODES.OUTPUT);
+      board.digitalWrite(x.pin, board.LOW);
     });
   };
   const initializer = {


### PR DESCRIPTION
…is high.

This makes accidentally connected LED on V9 off while V9 is not setup to use LED.  Note that connecting LED on V9 while using MultiLED or while V9 is not setup to use LED is still prohibited usage by specification.